### PR TITLE
Fix reload exclusion comment

### DIFF
--- a/fastapi_app/start_dev.py
+++ b/fastapi_app/start_dev.py
@@ -14,7 +14,7 @@ def main():
     # Change to the fastapi_app directory
     os.chdir(current_dir)
     
-    # Use uv run uvicorn with reload-excludes to exclude the data directory
+    # Use uv run uvicorn with reload-excludes to ignore data/, *.db, and __pycache__/
     cmd = [
         "uv", "run", "uvicorn",
         "main:app",


### PR DESCRIPTION
## Summary
- clarify which paths are excluded from uvicorn reload

## Testing
- `make test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee06e76608330a3287049f730ca6b