### PR TITLE
Add OpenAPI spec and tests

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,165 @@
+openapi: 3.0.3
+info:
+  title: PDF Processor API
+  version: "1.0.0"
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is running
+  /pdfs:
+    get:
+      summary: List processed PDFs
+      responses:
+        '200':
+          description: List of PDFs
+    post:
+      summary: Process a PDF from a URI
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                uri:
+                  type: string
+              required:
+                - uri
+            example:
+              uri: http://example.com/sample.pdf
+      responses:
+        '200':
+          description: Processing result
+  /pdfs/{uri}:
+    parameters:
+      - in: path
+        name: uri
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get PDF record by URI
+      responses:
+        '200':
+          description: PDF information
+        '404':
+          description: PDF not found
+    delete:
+      summary: Delete PDF record by URI
+      responses:
+        '200':
+          description: Deletion result
+        '404':
+          description: PDF not found
+  /convert/{uri}:
+    parameters:
+      - in: path
+        name: uri
+        required: true
+        schema:
+          type: string
+    post:
+      summary: Manually trigger conversion
+      responses:
+        '200':
+          description: Conversion result
+        '404':
+          description: PDF not found
+  /convert/process-queue:
+    post:
+      summary: Process pending conversions
+      responses:
+        '200':
+          description: Queue processed
+  /stats:
+    get:
+      summary: Get processing statistics
+      responses:
+        '200':
+          description: Statistics
+  /duplicates:
+    get:
+      summary: Get duplicate content stats
+      responses:
+        '200':
+          description: Duplicate data
+  /deduplicate:
+    post:
+      summary: Update content hashes for existing files
+      responses:
+        '200':
+          description: Deduplication result
+  /extract/{paper_id}:
+    parameters:
+      - in: path
+        name: paper_id
+        required: true
+        schema:
+          type: integer
+    post:
+      summary: Trigger extraction for a PDF
+      responses:
+        '200':
+          description: Extraction result
+        '404':
+          description: PDF not found
+    get:
+      summary: Get extraction results
+      responses:
+        '200':
+          description: Extraction data
+        '404':
+          description: Not found
+  /extract/process-queue:
+    post:
+      summary: Process pending extractions
+      responses:
+        '200':
+          description: Queue processed
+  /extract/template:
+    get:
+      summary: Get extraction template
+      responses:
+        '200':
+          description: Template
+  /extract/{paper_id}/selective:
+    parameters:
+      - in: path
+        name: paper_id
+        required: true
+        schema:
+          type: integer
+    post:
+      summary: Selective extraction of fields
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                selected_fields:
+                  type: array
+                  items:
+                    type: string
+                selected_models:
+                  type: array
+                  items:
+                    type: string
+                selected_size:
+                  type: string
+              required:
+                - selected_fields
+            example:
+              selected_fields: ["title"]
+              selected_models: ["model1"]
+              selected_size: medium
+      responses:
+        '200':
+          description: Selective extraction result
+        '404':
+          description: PDF not found
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,152 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+import yaml
+import pytest
+from fastapi.testclient import TestClient
+
+@pytest.fixture(scope="session")
+def app():
+    # Create stub modules required by main
+    processor = types.ModuleType("processor")
+    from pydantic import BaseModel
+    class ProcessInputData(BaseModel):
+        uri: str
+    def process_pdf(data: ProcessInputData):
+        return {"uri": data.uri, "downloaded": True, "is_pdf": True, "file_path": "file.pdf"}
+    processor.ProcessInputData = ProcessInputData
+    processor.process_pdf = process_pdf
+    sys.modules["processor"] = processor
+
+    database = types.ModuleType("database")
+    def init_database():
+        pass
+    def get_all_processed_pdfs():
+        return []
+    def get_processed_pdf(uri: str):
+        return {"uri": uri, "file_path": "file.pdf", "is_downloaded": True, "status": "success", "is_converted": True, "is_extracted": True, "extraction_file_path": "res.json"}
+    def get_processed_pdf_by_id(pid: int):
+        return {"id": pid, "uri": f"uri{pid}", "is_converted": True, "is_extracted": True, "extraction_file_path": "res.json"}
+    def delete_processed_pdf(uri: str):
+        return True
+    def get_processing_stats():
+        return {"total": 0}
+    def check_uri_exists(uri: str):
+        return None
+    def check_content_exists(h: str):
+        return None
+    def hash_file_content(p: str):
+        return "hash"
+    def reset_interrupted_conversions():
+        return 0
+    def reset_interrupted_extractions():
+        return 0
+    import contextlib
+    @contextlib.contextmanager
+    def get_db_connection():
+        class DummyCursor:
+            def execute(self, *args, **kwargs):
+                pass
+            def fetchall(self):
+                return []
+            def fetchone(self):
+                return (0, 0, 0)
+        class DummyConn:
+            def cursor(self):
+                return DummyCursor()
+            def commit(self):
+                pass
+            def close(self):
+                pass
+        yield DummyConn()
+    database.init_database = init_database
+    database.get_all_processed_pdfs = get_all_processed_pdfs
+    database.get_processed_pdf = get_processed_pdf
+    database.get_processed_pdf_by_id = get_processed_pdf_by_id
+    database.delete_processed_pdf = delete_processed_pdf
+    database.get_processing_stats = get_processing_stats
+    database.check_uri_exists = check_uri_exists
+    database.check_content_exists = check_content_exists
+    database.hash_file_content = hash_file_content
+    database.reset_interrupted_conversions = reset_interrupted_conversions
+    database.reset_interrupted_extractions = reset_interrupted_extractions
+    database.get_db_connection = get_db_connection
+    sys.modules["database"] = database
+
+    conv = types.ModuleType("conversion_service")
+    async def convert_pdf_async(uri: str):
+        return {"converted": uri}
+    async def process_conversion_queue():
+        return []
+    conv.convert_pdf_async = convert_pdf_async
+    conv.process_conversion_queue = process_conversion_queue
+    sys.modules["conversion_service"] = conv
+
+    ext = types.ModuleType("extraction_service")
+    async def extract_pdf_async(uri: str):
+        return {"extracted": uri}
+    async def process_extraction_queue():
+        return []
+    async def extract_pdf_selective_async(uri, fields, models, size):
+        return {"extracted": uri, "fields": fields}
+    def get_extraction_template():
+        return {"fields": [{"title": "title"}], "models": [{"name": "model1"}]}
+    ext.extract_pdf_async = extract_pdf_async
+    ext.process_extraction_queue = process_extraction_queue
+    ext.extract_pdf_selective_async = extract_pdf_selective_async
+    ext.get_extraction_template = get_extraction_template
+    sys.modules["extraction_service"] = ext
+
+    config = types.ModuleType("config")
+    def resolve_file_path(p: str):
+        return Path(p)
+    config.resolve_file_path = resolve_file_path
+    sys.modules["config"] = config
+
+    llm_pkg = types.ModuleType("llm")
+    questions_mod = types.ModuleType("llm.questions")
+    questions_mod.question_list = []
+    llm_mod = types.ModuleType("llm.llm")
+    llm_mod.model_list = []
+    sys.modules["llm"] = llm_pkg
+    sys.modules["llm.questions"] = questions_mod
+    sys.modules["llm.llm"] = llm_mod
+
+    sys.path.insert(0, "fastapi_app")
+    main = importlib.import_module("main")
+    return main.app
+
+
+def load_spec():
+    with open(Path("docs/openapi.yaml"), "r") as f:
+        return yaml.safe_load(f)
+
+
+def test_openapi_valid():
+    spec = load_spec()
+    assert "paths" in spec
+    assert "/health" in spec["paths"]
+
+
+def test_endpoints_from_spec(app):
+    client = TestClient(app)
+    spec = load_spec()
+    for path, operations in spec["paths"].items():
+        for method in operations.keys():
+            url = path.replace("{uri}", "test").replace("{paper_id}", "1")
+            if method == "get":
+                response = client.get(url)
+            elif method == "post":
+                body = {}
+                if "requestBody" in operations[method]:
+                    if path.startswith("/pdfs") and method == "post":
+                        body = {"uri": "http://example.com/sample.pdf"}
+                    elif path.endswith("/selective"):
+                        body = {"selected_fields": ["title"]}
+                response = client.post(url, json=body)
+            elif method == "delete":
+                response = client.delete(url)
+            else:
+                continue
+            assert response.status_code < 500


### PR DESCRIPTION
## Summary
- document the FastAPI endpoints in `docs/openapi.yaml`
- add a small test suite exercising each endpoint described in the spec

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ee49842a4833088a1d1538b8b829a